### PR TITLE
mybinder dns redirect version

### DIFF
--- a/infra/environments/main.tf
+++ b/infra/environments/main.tf
@@ -51,6 +51,17 @@ module "downloads" {
 }
 
 
+module "jupyter_notebook" {
+  source = "../modules/curi/jupyter_sdk"
+  count  = contains(["prod", "modl", "test"], terraform.workspace) ? 1 : 0
+
+  hosted_zone    = var.hosted_zone
+  hosted_zone_id = module.downloads[0].hosted_zone_id
+  ssl_cert_arn   = module.downloads[0].ssl_cert_arn
+  version_tag    = "v0.13.2"
+}
+
+
 module "lambda" {
   source = "../modules/curi/lambda"
 

--- a/infra/modules/curi/jupyter_sdk/dns.tf
+++ b/infra/modules/curi/jupyter_sdk/dns.tf
@@ -1,0 +1,8 @@
+resource "aws_route53_record" "jupyter_cname" {
+  allow_overwrite = true
+  zone_id         = var.hosted_zone_id
+  name            = "jupyter-sdk.${var.hosted_zone}"
+  type            = "CNAME"
+  ttl             = 3600
+  records         = [aws_cloudfront_distribution.jupyter_sdk_distribution.domain_name]
+}

--- a/infra/modules/curi/jupyter_sdk/s3.tf
+++ b/infra/modules/curi/jupyter_sdk/s3.tf
@@ -1,13 +1,20 @@
 resource "aws_cloudfront_distribution" "jupyter_sdk_distribution" {
   origin {
-    domain_name = aws_s3_bucket.jupyter.bucket_regional_domain_name
+    domain_name = "jupyter-sdk.${var.hosted_zone}.s3-website-us-east-1.amazonaws.com"
     origin_id   = "website"
+
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port = 80
+      https_port = 443
+      origin_ssl_protocols = ["TLSv1.2", "TLSv1.1", "TLSv1"]
+    }
   }
+
 
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "Managed by Terraform"
-  default_root_object = "index.html"
 
   aliases = ["jupyter-sdk.${var.hosted_zone}"]
 
@@ -26,7 +33,7 @@ resource "aws_cloudfront_distribution" "jupyter_sdk_distribution" {
 
     viewer_protocol_policy = "allow-all"
     min_ttl                = 0
-    default_ttl            = 3600
+    default_ttl            = 60
     max_ttl                = 86400
   }
 
@@ -54,6 +61,7 @@ resource "aws_s3_bucket" "jupyter" {
     routing_rules = <<EOF
       [{
           "Redirect": {
+            "HttpRedirectCode": "302",
             "HostName": "mybinder.org",
             "ReplaceKeyWith": "v2/gh/curibio/jupyter_sdk/${var.version_tag}?filepath=intro.ipynb"
           }

--- a/infra/modules/curi/jupyter_sdk/s3.tf
+++ b/infra/modules/curi/jupyter_sdk/s3.tf
@@ -1,0 +1,63 @@
+resource "aws_cloudfront_distribution" "jupyter_sdk_distribution" {
+  origin {
+    domain_name = aws_s3_bucket.jupyter.bucket_regional_domain_name
+    origin_id   = "website"
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Managed by Terraform"
+  default_root_object = "index.html"
+
+  aliases = ["jupyter-sdk.${var.hosted_zone}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "website"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = var.ssl_cert_arn
+    ssl_support_method  = "sni-only"
+  }
+}
+resource "aws_s3_bucket" "jupyter" {
+  bucket = "jupyter-sdk.${var.hosted_zone}"
+  acl    = "public-read"
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+
+    routing_rules = <<EOF
+      [{
+          "Redirect": {
+            "HostName": "mybinder.org",
+            "ReplaceKeyPrefixWith": "v2/gh/curibio/jupyter_sdk/${var.version_tag}?filepath=intro.ipynb"
+          }
+      }]
+      EOF
+  }
+}

--- a/infra/modules/curi/jupyter_sdk/s3.tf
+++ b/infra/modules/curi/jupyter_sdk/s3.tf
@@ -5,16 +5,16 @@ resource "aws_cloudfront_distribution" "jupyter_sdk_distribution" {
 
     custom_origin_config {
       origin_protocol_policy = "http-only"
-      http_port = 80
-      https_port = 443
-      origin_ssl_protocols = ["TLSv1.2", "TLSv1.1", "TLSv1"]
+      http_port              = 80
+      https_port             = 443
+      origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1", "TLSv1"]
     }
   }
 
 
-  enabled             = true
-  is_ipv6_enabled     = true
-  comment             = "Managed by Terraform"
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "Managed by Terraform"
 
   aliases = ["jupyter-sdk.${var.hosted_zone}"]
 

--- a/infra/modules/curi/jupyter_sdk/s3.tf
+++ b/infra/modules/curi/jupyter_sdk/s3.tf
@@ -55,7 +55,7 @@ resource "aws_s3_bucket" "jupyter" {
       [{
           "Redirect": {
             "HostName": "mybinder.org",
-            "ReplaceKeyPrefixWith": "v2/gh/curibio/jupyter_sdk/${var.version_tag}?filepath=intro.ipynb"
+            "ReplaceKeyWith": "v2/gh/curibio/jupyter_sdk/${var.version_tag}?filepath=intro.ipynb"
           }
       }]
       EOF

--- a/infra/modules/curi/jupyter_sdk/variables.tf
+++ b/infra/modules/curi/jupyter_sdk/variables.tf
@@ -1,0 +1,19 @@
+variable "hosted_zone" {
+  description = "Hosted zone"
+  type = string
+}
+
+variable "version_tag" {
+  description = "Github tag"
+  type = string
+}
+
+variable "hosted_zone_id" {
+  description = "Hosted zone id"
+  type = string
+}
+
+variable "ssl_cert_arn" {
+  description = "SSL cert arn for hosted zone"
+  type = string
+}

--- a/infra/modules/curi/jupyter_sdk/variables.tf
+++ b/infra/modules/curi/jupyter_sdk/variables.tf
@@ -1,19 +1,19 @@
 variable "hosted_zone" {
   description = "Hosted zone"
-  type = string
+  type        = string
 }
 
 variable "version_tag" {
   description = "Github tag"
-  type = string
+  type        = string
 }
 
 variable "hosted_zone_id" {
   description = "Hosted zone id"
-  type = string
+  type        = string
 }
 
 variable "ssl_cert_arn" {
   description = "SSL cert arn for hosted zone"
-  type = string
+  type        = string
 }

--- a/infra/modules/curi/s3_downloads/outputs.tf
+++ b/infra/modules/curi/s3_downloads/outputs.tf
@@ -1,0 +1,7 @@
+output "hosted_zone_id" {
+  value = aws_route53_zone.main.zone_id
+}
+
+output "ssl_cert_arn" {
+  value = aws_acm_certificate.cert.arn
+}


### PR DESCRIPTION
setup dns for jupyter-sdk subdomain, cloudfront to handle ssl certs, s3 bucket to handle redirects to mybinder site.

It's running in the test env now,
[curibio.sdk](https://jupyter-sdk.curibio-test.com)